### PR TITLE
Added a first ros2_control hardware interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ compile_commands.json
 /.cache/
 /ros2_interfaces_ws/install/
 /ros2_interfaces_ws/log/
+/ros2_components_ws/install/
+/ros2_components_ws/log/

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 add_subdirectory(ros2_frameTransform_config)
+add_subdirectory(ros2_control_demo)

--- a/resources/ros2_control_demo/CMakeLists.txt
+++ b/resources/ros2_control_demo/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2023 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+set(RESNAME ros2_control_demo)
+
+file(GLOB apps ${CMAKE_CURRENT_SOURCE_DIR}/scripts/*.xml)
+
+yarp_install(FILES ${apps}    DESTINATION ${YARP-DEVICES-ROS2_APPLICATIONS_INSTALL_DIR})

--- a/resources/ros2_control_demo/scripts/ros2_control_R1SN003.xml
+++ b/resources/ros2_control_demo/scripts/ros2_control_R1SN003.xml
@@ -14,7 +14,7 @@
 
    <module>
       <name>ros2</name>
-      <parameters>launch cer_ros2_control cer_R1SN003_neck_pos_only.launch.py launch_rviz2</parameters>
+      <parameters>launch cer_ros2_control cer_R1SN003_neck_pos_only.launch.py</parameters>
       <node>r1-base</node>
    </module>
 

--- a/resources/ros2_control_demo/scripts/ros2_control_R1SN003.xml
+++ b/resources/ros2_control_demo/scripts/ros2_control_R1SN003.xml
@@ -1,0 +1,34 @@
+<application>
+   <name>ros2_control_demo_R1SN003</name>
+   <dependencies>
+   </dependencies>
+
+   <!-- modules -->
+
+   <module>
+      <name>yarprobotinterface</name>
+      <parameters></parameters>
+      <workdir>/home/user1/robotology/robots-configuration/R1SN003/</workdir>
+      <node>r1-base</node>
+   </module>
+
+   <module>
+      <name>ros2</name>
+      <parameters>launch cer_ros2_control cer_R1SN003_neck_pos_only.launch.py launch_rviz2</parameters>
+      <node>r1-base</node>
+   </module>
+
+   <module>
+      <name>yarpmotorgui</name>
+      <parameters></parameters>
+      <workdir>/home/user1/robotology/robots-configuration/R1SN003/</workdir>
+      <node>console</node>
+   </module>
+
+   <module>
+      <name>rviz2</name>
+      <parameters>-d cer_config.rviz</parameters>
+      <workdir>/home/user1/robotology/cer-sim/colcon_ws/src/cer_rviz2/rviz2</workdir>
+      <node>console</node>
+   </module>
+</application>

--- a/ros2_components_ws/src/cb_hw_fw_pos/CMakeLists.txt
+++ b/ros2_components_ws/src/cb_hw_fw_pos/CMakeLists.txt
@@ -1,0 +1,97 @@
+cmake_minimum_required(VERSION 3.8)
+project(cb_hw_fw_pos)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(control_msgs REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(rcpputils REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(yarp_control_msgs REQUIRED)
+
+add_library(${PROJECT_NAME}
+  SHARED
+  src/cb_hw_fw_pos.cpp
+  )
+target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+target_include_directories(
+  ${PROJECT_NAME}
+  PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+ament_target_dependencies(
+  ${PROJECT_NAME}
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+  lifecycle_msgs
+  control_msgs
+  rcpputils
+  rcutils
+  yarp_control_msgs
+)
+
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME} PRIVATE "CB_HW_FW_POS_BUILDING_LIBRARY")
+
+#target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+pluginlib_export_plugin_description_file(hardware_interface ${PROJECT_NAME}.xml)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  DESTINATION lib
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_include_directories(
+  include
+)
+
+ament_export_libraries(
+  ${PROJECT_NAME}
+)
+
+ament_export_targets(
+ export_${PROJECT_NAME}
+)
+
+ament_export_dependencies(
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+)
+
+ament_package()

--- a/ros2_components_ws/src/cb_hw_fw_pos/cb_hw_fw_pos.xml
+++ b/ros2_components_ws/src/cb_hw_fw_pos/cb_hw_fw_pos.xml
@@ -1,0 +1,9 @@
+<library path="cb_hw_fw_pos">
+    <class name="cb_hw_fw_pos/CbHwFwPos"
+           type="cb_hw_fw_pos::CbHwFwPos"
+           base_class_type="hardware_interface::SystemInterface">
+        <description>
+            Hardware interface to forward position commands to yarp controlBoard_nws_ros2
+        </description>
+    </class>
+</library>

--- a/ros2_components_ws/src/cb_hw_fw_pos/include/cb_hw_fw_pos/cb_hw_fw_pos.hpp
+++ b/ros2_components_ws/src/cb_hw_fw_pos/include/cb_hw_fw_pos/cb_hw_fw_pos.hpp
@@ -57,9 +57,7 @@ private:
     std::string  m_posTopicName;                 // Position commands topic
     std::string  m_getModesClientName;           // Service client for joints current control modes
     std::string  m_getPositionClientName;        // Service client to get current position values
-    std::string  m_setModesClientName;           // Service client to set joints control modes
     std::string  m_getJointsNamesClientName;     // Service client to get the available joints names
-    std::string  m_getAvailableModesClientName;  // Services client to get the available control modes
     mutable std::mutex       m_cmdMutex;
     std::vector<std::string> m_jointNames; // name of the joints
 
@@ -82,8 +80,6 @@ private:
     rclcpp::Client<yarp_control_msgs::srv::GetJointsNames>::SharedPtr           m_getJointsNamesClient;
     rclcpp::Client<yarp_control_msgs::srv::GetControlModes>::SharedPtr          m_getControlModesClient;
     rclcpp::Client<yarp_control_msgs::srv::GetPosition>::SharedPtr              m_getPositionClient;
-    rclcpp::Client<yarp_control_msgs::srv::SetControlModes>::SharedPtr          m_setControlModesClient;
-    rclcpp::Client<yarp_control_msgs::srv::GetAvailableControlModes>::SharedPtr m_getAvailableModesClient;
 
     // Internal functions
     /* Check whether or not the joints specified in the ros2 robot configuration files are actually

--- a/ros2_components_ws/src/cb_hw_fw_pos/include/cb_hw_fw_pos/cb_hw_fw_pos.hpp
+++ b/ros2_components_ws/src/cb_hw_fw_pos/include/cb_hw_fw_pos/cb_hw_fw_pos.hpp
@@ -1,0 +1,115 @@
+#ifndef CB_HW_FW_POS__CB_HW_FW_POS_HPP_
+#define CB_HW_FW_POS__CB_HW_FW_POS_HPP_
+
+#include <string>
+#include <vector>
+
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+#include <rclcpp/rclcpp.hpp>
+
+//Custom ros2 interfaces
+#include <yarp_control_msgs/srv/get_control_modes.hpp>
+#include <yarp_control_msgs/srv/get_position.hpp>
+#include <yarp_control_msgs/srv/get_velocity.hpp>
+#include <yarp_control_msgs/srv/set_control_modes.hpp>
+#include <yarp_control_msgs/srv/get_available_control_modes.hpp>
+#include <yarp_control_msgs/srv/get_joints_names.hpp>
+#include <yarp_control_msgs/msg/position.hpp>
+#include <yarp_control_msgs/msg/velocity.hpp>
+#include <yarp_control_msgs/msg/position_direct.hpp>
+
+#include <mutex>
+
+#include "cb_hw_fw_pos/visibility_control.h"
+
+namespace cb_hw_fw_pos {
+
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+class CbHwFwPos : public hardware_interface::SystemInterface
+{
+private:
+    bool         m_active{false};
+    bool         m_continuousPosWrite{true};
+    std::string  m_nodeName;             // name of the rosNode
+    std::string  m_jointStateTopicName;  // name of the rosTopic
+    std::string  m_msgs_name;
+    std::string  m_posTopicName;
+    std::string  m_getModesClientName;
+    std::string  m_getPositionClientName;
+    std::string  m_setModesClientName;
+    std::string  m_getJointsNamesClientName;
+    std::string  m_getAvailableModesClientName;
+    mutable std::mutex       m_cmdMutex;
+    std::vector<std::string> m_jointNames; // name of the joints
+
+    // State and command interfaces
+    // Store the commands for the simulated robot
+    std::vector<double> m_hwCommandsPositions;
+    std::vector<double> m_oldPositions; // This array has to be used in order to avoid sending
+                                        // the same position commans over and over
+    std::vector<std::string> m_modes; // Current joints control modes.
+                                      // We have to assume that the joints do not change
+                                      // control mode without this hw interface class knowing.
+                                      // In other words, the only way to switch control mode
+                                      // should be via "perform_command_mode_switch" method.
+
+    // Ros2 related attributes
+    rclcpp::Node::SharedPtr m_node;
+    rclcpp::Publisher<yarp_control_msgs::msg::Position>::SharedPtr               m_posPublisher;
+    rclcpp::Client<yarp_control_msgs::srv::GetJointsNames>::SharedPtr           m_getJointsNamesClient;
+    rclcpp::Client<yarp_control_msgs::srv::GetControlModes>::SharedPtr          m_getControlModesClient;
+    rclcpp::Client<yarp_control_msgs::srv::GetPosition>::SharedPtr              m_getPositionClient;
+    rclcpp::Client<yarp_control_msgs::srv::SetControlModes>::SharedPtr          m_setControlModesClient;
+    rclcpp::Client<yarp_control_msgs::srv::GetAvailableControlModes>::SharedPtr m_getAvailableModesClient;
+
+    // Internal functions
+    bool _checkJoints(const std::vector<hardware_interface::ComponentInfo>& joints);
+    CallbackReturn _initExportableInterfaces(const std::vector<hardware_interface::ComponentInfo>& joints);
+    CallbackReturn _getHWCurrentValues();
+
+public:
+    RCLCPP_SHARED_PTR_DEFINITIONS(CbHwFwPos)
+    CbHwFwPos();
+    ~CbHwFwPos();
+
+    // SystemInterface virtual functions
+    CB_HW_FW_POS_PUBLIC
+    CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
+
+    CB_HW_FW_POS_PUBLIC
+    std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+
+    CB_HW_FW_POS_PUBLIC
+    std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+    CB_HW_FW_POS_PUBLIC
+    hardware_interface::return_type prepare_command_mode_switch(const std::vector<std::string> & start_interfaces, const std::vector<std::string> & stop_interfaces) override;
+
+    CB_HW_FW_POS_PUBLIC
+    hardware_interface::return_type perform_command_mode_switch(const std::vector<std::string> & /*start_interfaces*/, const std::vector<std::string> & /*stop_interfaces*/) override;
+
+    CB_HW_FW_POS_PUBLIC
+    hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+    CB_HW_FW_POS_PUBLIC
+    hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+    CB_HW_FW_POS_PUBLIC
+    hardware_interface::return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+    CB_HW_FW_POS_PUBLIC
+    hardware_interface::return_type write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override;
+
+};
+
+}  // namespace cb_hw_fw_pos
+
+#endif  // CB_HW_FW_POS__CB_HW_INTERFACE_HPP_

--- a/ros2_components_ws/src/cb_hw_fw_pos/include/cb_hw_fw_pos/visibility_control.h
+++ b/ros2_components_ws/src/cb_hw_fw_pos/include/cb_hw_fw_pos/visibility_control.h
@@ -1,0 +1,35 @@
+#ifndef CB_HW_FW_POS__VISIBILITY_CONTROL_H_
+#define CB_HW_FW_POS__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define CB_HW_FW_POS_EXPORT __attribute__ ((dllexport))
+    #define CB_HW_FW_POS_IMPORT __attribute__ ((dllimport))
+  #else
+    #define CB_HW_FW_POS_EXPORT __declspec(dllexport)
+    #define CB_HW_FW_POS_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef CB_HW_FW_POS_BUILDING_LIBRARY
+    #define CB_HW_FW_POS_PUBLIC CB_HW_FW_POS_EXPORT
+  #else
+    #define CB_HW_FW_POS_PUBLIC CB_HW_FW_POS_IMPORT
+  #endif
+  #define CB_HW_FW_POS_PUBLIC_TYPE CB_HW_FW_POS_PUBLIC
+  #define CB_HW_FW_POS_LOCAL
+#else
+  #define CB_HW_FW_POS_EXPORT __attribute__ ((visibility("default")))
+  #define CB_HW_FW_POS_IMPORT
+  #if __GNUC__ >= 4
+    #define CB_HW_FW_POS_PUBLIC __attribute__ ((visibility("default")))
+    #define CB_HW_FW_POS_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define CB_HW_FW_POS_PUBLIC
+    #define CB_HW_FW_POS_LOCAL
+  #endif
+  #define CB_HW_FW_POS_PUBLIC_TYPE
+#endif
+
+#endif  // CB_HW_FW_POS__VISIBILITY_CONTROL_H_

--- a/ros2_components_ws/src/cb_hw_fw_pos/package.xml
+++ b/ros2_components_ws/src/cb_hw_fw_pos/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>cb_hw_fw_pos</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="ettore.landini@iit.it">user1</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>control_msgs</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>rcpputils</depend>
+  <depend>rcutils</depend>
+  <depend>hardware_interface</depend>
+  <depend>yarp_control_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2_components_ws/src/cb_hw_fw_pos/src/cb_hw_fw_pos.cpp
+++ b/ros2_components_ws/src/cb_hw_fw_pos/src/cb_hw_fw_pos.cpp
@@ -136,12 +136,6 @@ CallbackReturn CbHwFwPos::on_init(const hardware_interface::HardwareInfo & info)
     {
         return CallbackReturn::ERROR;
     }
-    /* controllare i giunti in ingresso e verificare che siano tra quelli disponibili tramite il client
-     * di getJointNames. A quel punto si espongono solo le interfacce di comando provenienti dall'esterno
-     * tramite il parametro "info".
-     * Le interfacce attive saranno quelle corrispondenti ai control mode dei vari giunti.
-     * Come si controlla sta cosa? Boh...
-     */
     if(info.hardware_parameters.count("node_name")<=0)
     {
         RCLCPP_FATAL(rclcpp::get_logger("CbHwFwPos"),"No node name specified");
@@ -261,18 +255,12 @@ hardware_interface::return_type CbHwFwPos::read(const rclcpp::Time & time, const
 
 hardware_interface::return_type CbHwFwPos::write(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
-    // RCLCPP_INFO(m_node->get_logger(), "####################################\n");
-    // for (auto x : m_hwCommandsPositions){
-    //     RCLCPP_INFO(m_node->get_logger(), "Got write: %f",x);
-    // }
-    // RCLCPP_INFO(m_node->get_logger(), "\n####################################");
     if(!m_active)
     {
         return hardware_interface::return_type::OK;
     }
     else if(m_hwCommandsPositions == m_oldPositions && !m_continuousPosWrite)
     {
-        //RCLCPP_INFO(m_node->get_logger(), "No changes in the stored command values. Skipping");
         return hardware_interface::return_type::OK;
     }
     yarp_control_msgs::msg::Position posToSend;

--- a/ros2_components_ws/src/cb_hw_fw_pos/src/cb_hw_fw_pos.cpp
+++ b/ros2_components_ws/src/cb_hw_fw_pos/src/cb_hw_fw_pos.cpp
@@ -1,0 +1,291 @@
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+#include <limits>
+#include <set>
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+
+#include "cb_hw_fw_pos/cb_hw_fw_pos.hpp"
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "rcutils/logging_macros.h"
+
+using namespace std::chrono_literals;
+
+namespace cb_hw_fw_pos
+{
+
+CbHwFwPos::CbHwFwPos()
+{
+}
+
+CbHwFwPos::~CbHwFwPos()
+{
+}
+
+bool CbHwFwPos::_checkJoints(const std::vector<hardware_interface::ComponentInfo>& joints)
+{
+    std::vector<std::string> all_joints;
+    auto namesRequest = std::make_shared<yarp_control_msgs::srv::GetJointsNames::Request>();
+    while (!m_getJointsNamesClient->wait_for_service(1s)) {
+        if (!rclcpp::ok()) {
+            RCLCPP_ERROR(m_node->get_logger(), "Interrupted while waiting for the service. Exiting.");
+            return false;
+        }
+        RCLCPP_INFO(m_node->get_logger(), "service not available, waiting again...");
+    }
+    auto namesResponse = m_getJointsNamesClient->async_send_request(namesRequest);
+    if(rclcpp::spin_until_future_complete(m_node, namesResponse) == rclcpp::FutureReturnCode::SUCCESS) {
+        RCLCPP_INFO(m_node->get_logger(), "Got joints names");
+        all_joints = namesResponse.get()->names;
+    }
+    else {
+        RCLCPP_ERROR(m_node->get_logger(),"Failed to get joints names");
+        return false;
+    }
+
+    for(const auto& joint : joints){
+        if (std::find(all_joints.begin(), all_joints.end(), joint.name) == all_joints.end())
+        {
+            RCLCPP_FATAL(m_node->get_logger(),"The joint named %s was not found among the available ones",
+                         joint.name.c_str());
+            return false;
+        }
+        m_jointNames.push_back(joint.name);
+    }
+    return true;
+}
+
+CallbackReturn CbHwFwPos::_initExportableInterfaces(const std::vector<hardware_interface::ComponentInfo>& joints)
+{
+    if(!_checkJoints(joints))
+    {
+        RCLCPP_FATAL(m_node->get_logger(),"Unable to initialize the joints. Check the previous errors for more details");
+        return CallbackReturn::ERROR;
+    }
+    m_hwCommandsPositions.resize(joints.size(), std::numeric_limits<double>::quiet_NaN());
+    m_oldPositions.resize(joints.size(), std::numeric_limits<double>::quiet_NaN());
+    size_t i=0;
+
+    for (const auto& joint : joints)
+    {
+        if (joint.command_interfaces.size() != 1)
+        {
+            RCLCPP_FATAL(
+                m_node->get_logger(),
+                "Joint '%s' has %zu command interfaces found. 1 expected.", joint.name.c_str(),
+                joint.command_interfaces.size());
+            return CallbackReturn::ERROR;
+        }
+
+        if (joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+        {
+            RCLCPP_FATAL(
+                m_node->get_logger(),
+                "This device supports only POSITION command interfaces. Check again your hardware configuration");
+            return CallbackReturn::ERROR;
+        }
+
+        m_hwCommandsPositions[i] = 0.0;
+        m_oldPositions[i++] = 0.0;
+    }
+
+    return _getHWCurrentValues();
+}
+
+CallbackReturn CbHwFwPos::_getHWCurrentValues()
+{
+    auto posRequest = std::make_shared<yarp_control_msgs::srv::GetPosition::Request>();
+    posRequest->names = m_jointNames;
+    while (!m_getPositionClient->wait_for_service(1s)) {
+        if (!rclcpp::ok()) {
+            RCLCPP_ERROR(m_node->get_logger(), "Interrupted while waiting for the service. Exiting.");
+            return CallbackReturn::ERROR;
+        }
+        RCLCPP_INFO(m_node->get_logger(), "service not available, waiting again...");
+    }
+    auto posFuture = m_getPositionClient->async_send_request(posRequest);
+    auto posResponse = std::make_shared<yarp_control_msgs::srv::GetPosition::Response>();
+    if(rclcpp::spin_until_future_complete(m_node, posFuture) == rclcpp::FutureReturnCode::SUCCESS) {
+        RCLCPP_INFO(m_node->get_logger(), "Got joints positions");
+        posResponse = posFuture.get();
+    }
+    else {
+        RCLCPP_ERROR(m_node->get_logger(),"Failed to get joints positions");
+        return CallbackReturn::ERROR;
+    }
+
+    for (size_t i=0; i<m_jointNames.size(); i++)
+    {
+        m_hwCommandsPositions[i] = posResponse->positions[i];
+        m_oldPositions[i] = posResponse->positions[i];
+    }
+
+    m_active = true;
+
+    return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn CbHwFwPos::on_init(const hardware_interface::HardwareInfo & info)
+{
+    if (
+    hardware_interface::SystemInterface::on_init(info) !=
+    hardware_interface::CallbackReturn::SUCCESS)
+    {
+        return CallbackReturn::ERROR;
+    }
+    /* controllare i giunti in ingresso e verificare che siano tra quelli disponibili tramite il client
+     * di getJointNames. A quel punto si espongono solo le interfacce di comando provenienti dall'esterno
+     * tramite il parametro "info".
+     * Le interfacce attive saranno quelle corrispondenti ai control mode dei vari giunti.
+     * Come si controlla sta cosa? Boh...
+     */
+    if(info.hardware_parameters.count("node_name")<=0)
+    {
+        RCLCPP_FATAL(rclcpp::get_logger("CbHwFwPos"),"No node name specified");
+        return CallbackReturn::ERROR;
+    }
+    if(info.hardware_parameters.count("cb_nws_msgs_name")<=0)
+    {
+        RCLCPP_FATAL(rclcpp::get_logger("CbHwFwPos"),"No msgs name for the controlBoard_nws_ros2 specified");
+        return CallbackReturn::ERROR;
+    }
+    if(info.hardware_parameters.count("continuous_pos_write")<=0)
+    {
+        RCLCPP_FATAL(rclcpp::get_logger("CbHwFwPos"),"No flag for the position continuous writing");
+        return CallbackReturn::ERROR;
+    }
+
+    m_nodeName = info_.hardware_parameters["node_name"];
+    m_msgs_name = info_.hardware_parameters["cb_nws_msgs_name"];
+    m_continuousPosWrite = info_.hardware_parameters["continuous_pos_write"]==std::string("true") || info_.hardware_parameters["continuous_pos_write"]==std::string("True");
+
+    m_node = rclcpp::Node::make_shared(m_nodeName);
+
+    // Initialize topics and services names ------------------------------------------------------------------- //
+    m_posTopicName = m_msgs_name+"/position";
+    m_getModesClientName = m_msgs_name+"/get_modes";
+    m_setModesClientName = m_msgs_name+"/set_modes";
+    m_getPositionClientName = m_msgs_name+"/get_position";
+    m_getAvailableModesClientName = m_msgs_name+"/get_available_modes";
+    m_getJointsNamesClientName = m_msgs_name+"/get_joints_names";
+
+    // Initialize publishers ---------------------------------------------------------------------------------- //
+    m_posPublisher = m_node->create_publisher<yarp_control_msgs::msg::Position>(m_posTopicName, 10);
+    if(!m_posPublisher){
+        RCLCPP_ERROR(m_node->get_logger(),"Could not initialize the Position publisher");
+        return CallbackReturn::ERROR;
+    }
+
+    // Initialize services clients ---------------------------------------------------------------------------- //
+    m_getJointsNamesClient = m_node->create_client<yarp_control_msgs::srv::GetJointsNames>(m_getJointsNamesClientName);
+    if(!m_getJointsNamesClient){
+        RCLCPP_ERROR(m_node->get_logger(),"Could not initialize the GetJointsNames service client");
+        return CallbackReturn::ERROR;
+    }
+    m_getControlModesClient = m_node->create_client<yarp_control_msgs::srv::GetControlModes>(m_getModesClientName);
+    if(!m_getControlModesClient){
+        RCLCPP_ERROR(m_node->get_logger(),"Could not initialize the GetControlModes service client");
+        return CallbackReturn::ERROR;
+    }
+    m_getPositionClient = m_node->create_client<yarp_control_msgs::srv::GetPosition>(m_getPositionClientName);
+    if(!m_getPositionClient){
+        RCLCPP_ERROR(m_node->get_logger(),"Could not initialize the GetPosition service client");
+        return CallbackReturn::ERROR;
+    }
+    m_setControlModesClient = m_node->create_client<yarp_control_msgs::srv::SetControlModes>(m_setModesClientName);
+    if(!m_setControlModesClient){
+        RCLCPP_ERROR(m_node->get_logger(),"Could not initialize the SetControlModes service client");
+        return CallbackReturn::ERROR;
+    }
+    m_getAvailableModesClient = m_node->create_client<yarp_control_msgs::srv::GetAvailableControlModes>(m_getAvailableModesClientName);
+    if(!m_getAvailableModesClient){
+        RCLCPP_ERROR(m_node->get_logger(),"Could not initialize the GetAvailableControlModes service client");
+        return CallbackReturn::ERROR;
+    }
+
+    return _initExportableInterfaces(info_.joints);
+}
+
+std::vector<hardware_interface::StateInterface> CbHwFwPos::export_state_interfaces()
+{
+    std::vector<hardware_interface::StateInterface> ifacesToReturn;
+    return ifacesToReturn;
+}
+
+std::vector<hardware_interface::CommandInterface> CbHwFwPos::export_command_interfaces()
+{
+    std::vector<hardware_interface::CommandInterface> ifacesToReturn;
+    for (size_t i=0; i<m_hwCommandsPositions.size(); i++)
+    {
+        ifacesToReturn.emplace_back(hardware_interface::CommandInterface(
+            info_.joints[i].name, hardware_interface::HW_IF_POSITION, &m_hwCommandsPositions[i]));
+    }
+
+    return ifacesToReturn;
+}
+
+hardware_interface::return_type CbHwFwPos::prepare_command_mode_switch(const std::vector<std::string> & start_interfaces, const std::vector<std::string> & stop_interfaces)
+{
+    return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type CbHwFwPos::perform_command_mode_switch(const std::vector<std::string> & start_interfaces, const std::vector<std::string> & stop_interfaces)
+{
+    return hardware_interface::return_type::OK;
+}
+
+CallbackReturn CbHwFwPos::on_activate(const rclcpp_lifecycle::State & previous_state)
+{
+    if(_getHWCurrentValues() == CallbackReturn::ERROR)
+    {
+        RCLCPP_ERROR(m_node->get_logger(),"Could not successfully read the current joints positions. Check previous errors for more info");
+        return CallbackReturn::ERROR;
+    }
+    m_active = true;
+    return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn CbHwFwPos::on_deactivate(const rclcpp_lifecycle::State & previous_state)
+{
+    m_active = false;
+    return CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type CbHwFwPos::read(const rclcpp::Time & time, const rclcpp::Duration & period)
+{
+    return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type CbHwFwPos::write(const rclcpp::Time & time, const rclcpp::Duration & period)
+{
+    // RCLCPP_INFO(m_node->get_logger(), "####################################\n");
+    // for (auto x : m_hwCommandsPositions){
+    //     RCLCPP_INFO(m_node->get_logger(), "Got write: %f",x);
+    // }
+    // RCLCPP_INFO(m_node->get_logger(), "\n####################################");
+    if(!m_active)
+    {
+        return hardware_interface::return_type::OK;
+    }
+    else if(m_hwCommandsPositions == m_oldPositions && !m_continuousPosWrite)
+    {
+        //RCLCPP_INFO(m_node->get_logger(), "No changes in the stored command values. Skipping");
+        return hardware_interface::return_type::OK;
+    }
+    yarp_control_msgs::msg::Position posToSend;
+    posToSend.names = m_jointNames;
+    posToSend.positions = m_hwCommandsPositions;
+
+    m_posPublisher->publish(posToSend);
+    m_oldPositions = m_hwCommandsPositions;
+
+    return hardware_interface::return_type::OK;
+}
+
+}  // namespace cb_hw_fw_pos
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(cb_hw_fw_pos::CbHwFwPos, hardware_interface::SystemInterface)

--- a/ros2_interfaces_ws/src/yarp_control_msgs/CMakeLists.txt
+++ b/ros2_interfaces_ws/src/yarp_control_msgs/CMakeLists.txt
@@ -44,6 +44,8 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/SetControlModes.srv"
   "srv/GetControlModes.srv"
+  "srv/GetPosition.srv"
+  "srv/GetVelocity.srv"
   "srv/GetAvailableControlModes.srv"
   "srv/GetJointsNames.srv"
   "msg/Position.msg"

--- a/ros2_interfaces_ws/src/yarp_control_msgs/srv/GetPosition.srv
+++ b/ros2_interfaces_ws/src/yarp_control_msgs/srv/GetPosition.srv
@@ -1,0 +1,10 @@
+# Service to get the current position for a set of joints
+# names: it can contain the names of the joints from which the position has to be retrieved. If left empty, the position of all the available joints will be returned
+string[] names
+---
+# modes: it will contain the position for the joints specified in "names" or for all them if "names" is empty
+# response: a brief string used to signal the state of the result of the request
+# opt_descr: An optional human readable description of the result of the request
+float64[] positions
+string response "NOT_SPECIFIED"
+string opt_descr

--- a/ros2_interfaces_ws/src/yarp_control_msgs/srv/GetVelocity.srv
+++ b/ros2_interfaces_ws/src/yarp_control_msgs/srv/GetVelocity.srv
@@ -1,0 +1,10 @@
+# Service to get the current velocity for a set of joints
+# names: it can contain the names of the joints from which the velocity has to be retrieved. If left empty, the velocity of all the available joints will be returned
+string[] names
+---
+# modes: it will contain the velocity for the joints specified in "names" or for all them if "names" is empty
+# response: a brief string used to signal the state of the result of the request
+# opt_descr: An optional human readable description of the result of the request
+float64[] velocities
+string response "NOT_SPECIFIED"
+string opt_descr

--- a/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2.cpp
+++ b/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2.cpp
@@ -130,6 +130,8 @@ bool ControlBoard_nws_ros2::initRos2Control(const std::string& name){
     m_velTopicName = name+"/velocity";
     m_getModesSrvName = name+"/get_modes";
     m_setModesSrvName = name+"/set_modes";
+    m_getVelocitySrvName = name+"/get_velocity";
+    m_getPositionSrvName = name+"/get_position";
     m_getAvailableModesSrvName = name+"/get_available_modes";
     m_getJointsNamesSrvName = name+"/get_joints_names";
 
@@ -195,6 +197,26 @@ bool ControlBoard_nws_ros2::initRos2Control(const std::string& name){
     if(!m_getControlModesSrv){
         yCError(CONTROLBOARD_ROS2) << "Could not initialize the GetControlModes service";
         RCLCPP_ERROR(m_node->get_logger(),"Could not initialize the GetControlModes service");
+
+        return false;
+    }
+    m_getPositionSrv = m_node->create_service<yarp_control_msgs::srv::GetPosition>(m_getPositionSrvName,
+                                                                                   std::bind(&ControlBoard_nws_ros2::getPositionCallback,
+                                                                                               this,std::placeholders::_1,std::placeholders::_2,
+                                                                                               std::placeholders::_3));
+    if(!m_getPositionSrv){
+        yCError(CONTROLBOARD_ROS2) << "Could not initialize the GetPosition service";
+        RCLCPP_ERROR(m_node->get_logger(),"Could not initialize the GetPosition service");
+
+        return false;
+    }
+    m_getVelocitySrv = m_node->create_service<yarp_control_msgs::srv::GetVelocity>(m_getVelocitySrvName,
+                                                                                   std::bind(&ControlBoard_nws_ros2::getVelocityCallback,
+                                                                                               this,std::placeholders::_1,std::placeholders::_2,
+                                                                                               std::placeholders::_3));
+    if(!m_getVelocitySrv){
+        yCError(CONTROLBOARD_ROS2) << "Could not initialize the GetVelocity service";
+        RCLCPP_ERROR(m_node->get_logger(),"Could not initialize the GetVelocity service");
 
         return false;
     }

--- a/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2.h
+++ b/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2.h
@@ -33,6 +33,8 @@
 
 //Custom ros2 interfaces
 #include <yarp_control_msgs/srv/get_control_modes.hpp>
+#include <yarp_control_msgs/srv/get_position.hpp>
+#include <yarp_control_msgs/srv/get_velocity.hpp>
 #include <yarp_control_msgs/srv/set_control_modes.hpp>
 #include <yarp_control_msgs/srv/get_available_control_modes.hpp>
 #include <yarp_control_msgs/srv/get_joints_names.hpp>
@@ -80,6 +82,8 @@ private:
     std::string                  m_posDirTopicName;
     std::string                  m_velTopicName;
     std::string                  m_getModesSrvName;
+    std::string                  m_getPositionSrvName;
+    std::string                  m_getVelocitySrvName;
     std::string                  m_setModesSrvName;
     std::string                  m_getJointsNamesSrvName;
     std::string                  m_getAvailableModesSrvName;
@@ -119,6 +123,8 @@ private:
     rclcpp::Subscription<yarp_control_msgs::msg::Velocity>::SharedPtr            m_velSubscription;
     rclcpp::Service<yarp_control_msgs::srv::GetJointsNames>::SharedPtr           m_getJointsNamesSrv;
     rclcpp::Service<yarp_control_msgs::srv::GetControlModes>::SharedPtr          m_getControlModesSrv;
+    rclcpp::Service<yarp_control_msgs::srv::GetPosition>::SharedPtr              m_getPositionSrv;
+    rclcpp::Service<yarp_control_msgs::srv::GetVelocity>::SharedPtr              m_getVelocitySrv;
     rclcpp::Service<yarp_control_msgs::srv::SetControlModes>::SharedPtr          m_setControlModesSrv;
     rclcpp::Service<yarp_control_msgs::srv::GetAvailableControlModes>::SharedPtr m_getAvailableModesSrv;
 
@@ -139,6 +145,12 @@ private:
     void getControlModesCallback(const std::shared_ptr<rmw_request_id_t> request_header,
                                  const std::shared_ptr<yarp_control_msgs::srv::GetControlModes::Request> request,
                                  std::shared_ptr<yarp_control_msgs::srv::GetControlModes::Response> response);
+    void getPositionCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                             const std::shared_ptr<yarp_control_msgs::srv::GetPosition::Request> request,
+                             std::shared_ptr<yarp_control_msgs::srv::GetPosition::Response> response);
+    void getVelocityCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                             const std::shared_ptr<yarp_control_msgs::srv::GetVelocity::Request> request,
+                             std::shared_ptr<yarp_control_msgs::srv::GetVelocity::Response> response);
     void setControlModesCallback(const std::shared_ptr<rmw_request_id_t> request_header,
                                  const std::shared_ptr<yarp_control_msgs::srv::SetControlModes::Request> request,
                                  std::shared_ptr<yarp_control_msgs::srv::SetControlModes::Response> response);

--- a/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2_callbacks.cpp
+++ b/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2_callbacks.cpp
@@ -68,6 +68,12 @@ inline double convertRadiansToDegrees(double degrees)
 {
     return degrees / M_PI * 180.0;
 }
+
+inline double convertDegreesToRadians(double radians)
+{
+    return radians / 180.0 * M_PI;
+}
+
 } // namespace
 
 // UTILITIES ------------------------------------------------------------------------------------------------------------- END //
@@ -470,6 +476,104 @@ void ControlBoard_nws_ros2::getControlModesCallback(const std::shared_ptr<rmw_re
     response->response = "OK";
 
     delete tempMode;
+}
+
+
+void ControlBoard_nws_ros2::getPositionCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                                                const std::shared_ptr<yarp_control_msgs::srv::GetPosition::Request> request,
+                                                std::shared_ptr<yarp_control_msgs::srv::GetPosition::Response> response) {
+    std::lock_guard <std::mutex> lg(m_cmdMutex);
+
+    bool noJoints = request->names.size() == 0;
+
+    if(!request){
+        yCError(CONTROLBOARD_ROS2) << "Invalid request";
+        RCLCPP_ERROR(m_node->get_logger(),"Invalid request");
+
+        response->response = "INVALID";
+
+        return;
+    }
+
+    if(!noJoints){
+        if(!namesCheck(request->names)){
+            response->response = "NAMES_ERROR";
+
+            return;
+        }
+    }
+
+    size_t forLimit = noJoints ? m_subdevice_joints : request->names.size();
+    double *tempPos = new double[m_jointNames.size()];
+    std::vector<double> positionsToSend;
+
+    if(!m_iEncodersTimed->getEncoders(tempPos)){
+        yCError(CONTROLBOARD_ROS2) << "Error while retrieving joints positions";
+        RCLCPP_ERROR(m_node->get_logger(),"Error while retrieving joints positions");
+        response->response = "RETRIEVE_ERROR";
+
+        delete tempPos;
+        return;
+    }
+
+    double posRad;
+    for (size_t i=0; i<forLimit; i++){
+        posRad = convertDegreesToRadians(tempPos[noJoints ? i : m_quickJointRef[request->names[i]]]);
+        positionsToSend.push_back(posRad);
+    }
+    response->positions = positionsToSend;
+    response->response = "OK";
+
+    delete tempPos;
+}
+
+
+void ControlBoard_nws_ros2::getVelocityCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                                                const std::shared_ptr<yarp_control_msgs::srv::GetVelocity::Request> request,
+                                                std::shared_ptr<yarp_control_msgs::srv::GetVelocity::Response> response) {
+    std::lock_guard <std::mutex> lg(m_cmdMutex);
+
+    bool noJoints = request->names.size() == 0;
+
+    if(!request){
+        yCError(CONTROLBOARD_ROS2) << "Invalid request";
+        RCLCPP_ERROR(m_node->get_logger(),"Invalid request");
+
+        response->response = "INVALID";
+
+        return;
+    }
+
+    if(!noJoints){
+        if(!namesCheck(request->names)){
+            response->response = "NAMES_ERROR";
+
+            return;
+        }
+    }
+
+    size_t forLimit = noJoints ? m_subdevice_joints : request->names.size();
+    double *tempVel = new double[m_jointNames.size()];
+    std::vector<double> velocitiesToSend;
+
+    if(!m_iEncodersTimed->getEncoderSpeeds(tempVel)){
+        yCError(CONTROLBOARD_ROS2) << "Error while retrieving joints speeds";
+        RCLCPP_ERROR(m_node->get_logger(),"Error while retrieving joints speeds");
+        response->response = "RETRIEVE_ERROR";
+
+        delete tempVel;
+        return;
+    }
+
+    double velRad;
+    for (size_t i=0; i<forLimit; i++){
+        velRad = convertDegreesToRadians(tempVel[noJoints ? i : m_quickJointRef[request->names[i]]]);
+        velocitiesToSend.push_back(velRad);
+    }
+    response->velocities = velocitiesToSend;
+    response->response = "OK";
+
+    delete tempVel;
 }
 
 

--- a/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2_callbacks.cpp
+++ b/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2_callbacks.cpp
@@ -516,10 +516,20 @@ void ControlBoard_nws_ros2::getPositionCallback(const std::shared_ptr<rmw_reques
         return;
     }
 
-    double posRad;
+    double position;
+    JointTypeEnum jType;
     for (size_t i=0; i<forLimit; i++){
-        posRad = convertDegreesToRadians(tempPos[noJoints ? i : m_quickJointRef[request->names[i]]]);
-        positionsToSend.push_back(posRad);
+        size_t index = noJoints ? i : m_quickJointRef[request->names[i]];
+        m_iAxisInfo->getJointType(index, jType);
+        if(jType == VOCAB_JOINTTYPE_REVOLUTE)
+        {
+            position = convertDegreesToRadians(tempPos[index]);
+        }
+        else
+        {
+            position = tempPos[index];
+        }
+        positionsToSend.push_back(position);
     }
     response->positions = positionsToSend;
     response->response = "OK";
@@ -565,10 +575,20 @@ void ControlBoard_nws_ros2::getVelocityCallback(const std::shared_ptr<rmw_reques
         return;
     }
 
-    double velRad;
+    double velocity;
+    JointTypeEnum jType;
     for (size_t i=0; i<forLimit; i++){
-        velRad = convertDegreesToRadians(tempVel[noJoints ? i : m_quickJointRef[request->names[i]]]);
-        velocitiesToSend.push_back(velRad);
+        size_t index = noJoints ? i : m_quickJointRef[request->names[i]];
+        m_iAxisInfo->getJointType(index, jType);
+        if(jType == VOCAB_JOINTTYPE_REVOLUTE)
+        {
+            velocity = convertDegreesToRadians(tempVel[index]);
+        }
+        else
+        {
+            velocity = tempVel[index];
+        }
+        velocitiesToSend.push_back(velocity);
     }
     response->velocities = velocitiesToSend;
     response->response = "OK";

--- a/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2_callbacks.cpp
+++ b/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2_callbacks.cpp
@@ -335,7 +335,7 @@ void ControlBoard_nws_ros2::velocityTopic_callback(const yarp_control_msgs::msg:
         }
         convertedVel.push_back(tempVel);
     }
-    if(!noJoints){
+    if(noJoints){
         if(!noAccel){
             m_iVelocityControl->setRefAccelerations(&convertedAccel[0]);
         }


### PR DESCRIPTION
This PR adds a first [hardware component](https://control.ros.org/master/doc/getting_started/getting_started.html#hardware-components) from the [ros2_control](https://control.ros.org/master/index.html)  framework that allows to control a set of joints my sending messages to a `controlBoard_nws_ros`.

For the moment being it is a "write-only" interface for position commands.

This pr also contains:
- a little correction for the `controlBoard_nws_ros2` (there was a little error in the velocityTopicCallback)
- two new ros2 services that allows to get joints position and velocity values from a `controlBoard_nws_ros2`
- A yarpmanager application xml file to test the new hardware_component (this will require also the new cer-sim repo ros2 package, added with PR [#42](https://github.com/robotology/cer-sim/pull/42))