### PR TITLE
Fix for static transforms - and miscellanea

### DIFF
--- a/src/devices/frameTransformGet_nwc_ros2/frameTransformGet_nwc_ros2.h
+++ b/src/devices/frameTransformGet_nwc_ros2/frameTransformGet_nwc_ros2.h
@@ -87,7 +87,6 @@ public:
     void frameTransformStaticGet_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg);
 
     //own
-    double yarpStampFromROS2(const builtin_interfaces::msg::Time& ros2Time);
     void ros2TransformToYARP(const geometry_msgs::msg::TransformStamped& input, yarp::math::FrameTransform& output, bool isStatic);
     bool updateBuffer(const std::vector<geometry_msgs::msg::TransformStamped>& transforms, bool areStatic);
     bool setTransform(const yarp::math::FrameTransform& transform);


### PR DESCRIPTION
Since in ROS2 the latched behaviour requires a specific QOS configuration, the frameTransformGet_nwc_ros2 tf_static subscription have been modified by passing a QoS profile qith transient local duration policy.

[The solution to the issue related to the latched topic applied in this PR has been found in the following issue: [ROS2#464](https://github.com/ros2/ros2/issues/464)]

Also, two minor changes have been applied: 1)lock in the callbacks, in order to avoid writing transforms in the buffer while a getTransforms query is ongoing; 2) The ros2 to yarp time conversion function have been replaced with the one in the Ros2Utils file (simply to avoid code duplication)