### PR TITLE
Fix assignment of z coordinate within frameTransformSet_nwc_ros2::yarpTransformToROS2Transform()

### DIFF
--- a/src/devices/frameTransformSet_nwc_ros2/frameTransformSet_nwc_ros2.cpp
+++ b/src/devices/frameTransformSet_nwc_ros2/frameTransformSet_nwc_ros2.cpp
@@ -151,7 +151,7 @@ void FrameTransformSet_nwc_ros2::yarpTransformToROS2Transform(const yarp::math::
 
     tempTransl.x = input.translation.tX;
     tempTransl.y = input.translation.tY;
-    tempTransl.z = input.translation.tY;
+    tempTransl.z = input.translation.tZ;
 
     tempRotation.w = input.rotation.w();
     tempRotation.x = input.rotation.x();


### PR DESCRIPTION
As per the title.

Fixes #56 