### PR TITLE
Fix test with latest version of YARP

### DIFF
--- a/src/devices/rangefinder2D_controlBoard_nws_ros2/tests/Rangefinder2D_controlBoard_nws_ros2_test.cpp
+++ b/src/devices/rangefinder2D_controlBoard_nws_ros2/tests/Rangefinder2D_controlBoard_nws_ros2_test.cpp
@@ -58,6 +58,7 @@ TEST_CASE("dev::rangefinder2D_controlBoard_nws_ros2_test", "[yarp::dev]")
         {
             Property pcfg_fake;
             pcfg_fake.put("device", "fakeLaserWithMotor");
+            pcfg_fake.put("test", "use_pattern");
             REQUIRE(ddfake.open(pcfg_fake));
         }
 

--- a/src/devices/rangefinder2D_nws_ros2/tests/Rangefinder2D_nws_ros2_test.cpp
+++ b/src/devices/rangefinder2D_nws_ros2/tests/Rangefinder2D_nws_ros2_test.cpp
@@ -56,6 +56,7 @@ TEST_CASE("dev::Rangefinder2D_nws_ros2_test", "[yarp::dev]")
         {
             Property pcfg_fake;
             pcfg_fake.put("device", "fakeLaser");
+            pcfg_fake.put("test", "use_pattern");
             REQUIRE(ddfake.open(pcfg_fake));
         }
 


### PR DESCRIPTION
The latest version of YARP (that will become YARP 3.10) has made the `test` parameter of `fakeLaser` and `fakeLaserWithMotor` compulsory. As `use_pattern` was the former default (see https://github.com/robotology/yarp/blob/v3.9.0/src/devices/fakeLaser/fakeLaser.cpp#L68), this PR fixes the CI by setting explicitly `test` to `use_pattern`.