### PR TITLE
Fixes for Imu_nws_ros2 to have imu output on ros2 coherent with the one in YARP

### DIFF
--- a/src/devices/multipleAnalogSensors_nws_ros2/Imu_nws_ros2.cpp
+++ b/src/devices/multipleAnalogSensors_nws_ros2/Imu_nws_ros2.cpp
@@ -54,12 +54,13 @@ void Imu_nws_ros2::run()
         yarp::sig::Vector vecacc(3);
         yarp::sig::Vector vecrpy(3);
         tf2::Quaternion quat;
-        quat.setRPY(vecrpy[0] * M_PI / 180.0, vecrpy[1] * M_PI / 180.0, vecrpy[2] * M_PI / 180.0);
-        quat.normalize();
         sensor_msgs::msg::Imu imu_ros_data;
+
         m_iThreeAxisGyroscopes->getThreeAxisGyroscopeMeasure(m_sens_index, vecgyr, m_timestamp);
         m_iThreeAxisLinearAccelerometers->getThreeAxisLinearAccelerometerMeasure(m_sens_index, vecacc, m_timestamp);
         m_iOrientationSensors->getOrientationSensorMeasureAsRollPitchYaw(m_sens_index, vecrpy, m_timestamp);
+        quat.setRPY(vecrpy[0] * M_PI / 180.0, vecrpy[1] * M_PI / 180.0, vecrpy[2] * M_PI / 180.0);
+        quat.normalize();
         imu_ros_data.header.frame_id = m_framename;
         imu_ros_data.header.stamp = ros2TimeFromYarp(m_timestamp);
         imu_ros_data.angular_velocity.x = vecgyr[0] * M_PI / 180.0;
@@ -71,7 +72,7 @@ void Imu_nws_ros2::run()
         imu_ros_data.orientation.x = quat.x();
         imu_ros_data.orientation.y = quat.y();
         imu_ros_data.orientation.z = quat.z();
-        imu_ros_data.orientation.z = quat.w();
+        imu_ros_data.orientation.w = quat.w();
         m_publisher->publish(imu_ros_data);
     }
 }


### PR DESCRIPTION
Changes:
1. Set values of quaternion after vecrpy has been initialized. 
2. Fix typo where quat component w was assigned to orientation component z.

With the proposed changes the orientation fields are now correctly populated 
![image](https://github.com/user-attachments/assets/f9dd90ee-da8e-4dba-950c-fe169777c97c)
![image](https://github.com/user-attachments/assets/54d2a616-719f-4f81-a6c0-479d1beb33d1)

When converted to euler angles, we can ascertain the conformity to the imu data provided by YARP shown below:

yarp read ... */imu/measures:o
...
(((0.99173901418694421217 -0.176201742695876545364 -0.339108696240359386298) 930.100999999999999091)) (((2.86410118451818229701 -0.0548334604433729569384 -9.32010341306919087856) 930.100999999999999091)) (((0.0 0.0 0.0) 930.100999999999999091)) (((**-179.986989286195182558 -17.2129761567645758191 -139.609585520027223993**) 930.100999999999999091))
...

@traversaro @Nicogene @randaz81 