### PR TITLE
Fixed RangeFinder2D_nwc_ros2 for yarp master compatibility

### DIFF
--- a/src/devices/rangefinder2D_nwc_ros2/Rangefinder2D_nwc_ros2.cpp
+++ b/src/devices/rangefinder2D_nwc_ros2/Rangefinder2D_nwc_ros2.cpp
@@ -85,7 +85,7 @@ void Rangefinder2D_nwc_ros2::callback(sensor_msgs::msg::LaserScan::SharedPtr msg
     m_timestamp = (msg->header.stamp.sec + (msg->header.stamp.nanosec / 1000000000));
 }
 
-bool Rangefinder2D_nwc_ros2::getLaserMeasurement(std::vector<yarp::dev::LaserMeasurementData> &data, double* timestamp)
+bool Rangefinder2D_nwc_ros2::getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp)
 {
     if (!m_data_valid) {return false;}
     std::lock_guard<std::mutex> data_guard(m_mutex);

--- a/src/devices/rangefinder2D_nwc_ros2/Rangefinder2D_nwc_ros2.h
+++ b/src/devices/rangefinder2D_nwc_ros2/Rangefinder2D_nwc_ros2.h
@@ -54,7 +54,7 @@ public:
 
 public:
     // IRangeFinder2D
-    bool getLaserMeasurement(std::vector<yarp::dev::LaserMeasurementData> &data, double* timestamp = nullptr) override;
+    bool getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp = nullptr) override;
     bool getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) override;
     bool getDeviceStatus(Device_status& status) override;
     bool getDistanceRange(double& min, double& max) override;


### PR DESCRIPTION
RangeFinder2D_nwc_ros2 is now compatible with yarp master.
**WARNING** If you are not using the latest version of yarp master you will not be able to build this version of the device