### PR TITLE
Remove VERSION argument from project invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,7 @@
 
 cmake_minimum_required(VERSION 3.17)
 project(yarp-devices-ros2
-        LANGUAGES CXX
-        VERSION 3.10.0)
+        LANGUAGES CXX)
 
 include(FeatureSummary)
 


### PR DESCRIPTION
The main `CMake` project does not install any CMake configuration file, so we can avoid to set a VERSION number there, to avoid confusion and the need to keep it maintained and aligned with the tag number (for example, the version is now `3.10.0` while the tag number is `1.0.0`).