### PR TITLE
Update yarp-devices-ros2 conda-ci to support Jazzy

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -59,17 +59,8 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        ros_distro: [humble, iron, jazzy]
+        ros_distro: [humble, jazzy]
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-2019]
-        exclude:
-          # iron, jazzy non yet supported by conda:
-          - ros_distro: iron
-          - ros_distro: jazzy
-          # incompatible combinations:
-          - os: ubuntu-22.04
-            ros_distro: jazzy
-          - os: ubuntu-24.04
-            ros_distro: iron
       fail-fast: false
 
     steps:
@@ -85,7 +76,7 @@ jobs:
         # Compilation related dependencies
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
-        conda install -c conda-forge -c robostack-staging ycm-cmake-modules eigen ace ros-${{ matrix.ros_distro }}-ros-base ros-${{ matrix.ros_distro }}-test-msgs
+        conda install -c conda-forge -c robostack-${{ matrix.ros_distro }} ycm-cmake-modules eigen ace ros-${{ matrix.ros_distro }}-ros-base ros-${{ matrix.ros_distro }}-test-msgs
 
 
     - name: Download YARP [Linux&macOS]
@@ -222,7 +213,7 @@ jobs:
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
         sudo apt-get install -qq -y libc6-dbg
-        conda install -c conda-forge -c robostack-staging ycm-cmake-modules eigen valgrind ace ros-${{ matrix.ros_distro }}-ros-base ros-${{ matrix.ros_distro }}-test-msgs
+        conda install -c conda-forge -c robostack-${{ matrix.ros_distro }} ycm-cmake-modules eigen valgrind ace ros-${{ matrix.ros_distro }}-ros-base ros-${{ matrix.ros_distro }}-test-msgs
 
     - name: Download YARP [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
Since https://github.com/RoboStack/ros-jazzy/pull/5 and several follow up PRs, robostack now provides ROS Jazzy packages, so we can use them in CI. I also removed `iron` from the CI, as it is now EOL: https://docs.ros.org/en/iron/Releases/End-of-Life.html .

