### PR TITLE
Rangefinder2D_nwc_yarp compatibility fix

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Check License
       run: |
         perl tests/misc/check_license.pl
-        
+
   check-tests:
     name: 'Check Devices Tests'
     runs-on: ubuntu-20.04
@@ -52,7 +52,7 @@ jobs:
     - name: Check Devices Tests
       run: |
         python3 tests/misc/check_tests.py
-        
+
   build:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}@${{ matrix.ros_distro }}@conda]'
     runs-on: ${{ matrix.os }}
@@ -83,7 +83,7 @@ jobs:
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       run: |
         cd ${GITHUB_WORKSPACE}
-        git clone -b yarp-3.11 https://github.com/robotology/yarp
+        git clone -b master https://github.com/robotology/yarp
 
     - name: Dependencies from source [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
@@ -106,7 +106,7 @@ jobs:
       shell: bash -l {0}
       run: |
         cd ${GITHUB_WORKSPACE}
-        git clone -b yarp-3.11 https://github.com/robotology/yarp
+        git clone -b master https://github.com/robotology/yarp
         cd yarp
         mkdir build
         cd build
@@ -219,7 +219,7 @@ jobs:
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       run: |
         cd ${GITHUB_WORKSPACE}
-        git clone -b yarp-3.11 https://github.com/robotology/yarp
+        git clone -b master https://github.com/robotology/yarp
 
     - name: Dependencies from source [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(YARP_FORCE_DYNAMIC_PLUGINS TRUE CACHE INTERNAL "yarp-devices-ros2 is always built with dynamic plugins")
 option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
 
-find_package(YARP 3.11.1 COMPONENTS os sig dev serversql OPTIONAL_COMPONENTS math REQUIRED)
-find_package(YARP 3.11.1 COMPONENTS catch2 dev_tests QUIET)
+find_package(YARP 3.11.100 COMPONENTS os sig dev serversql OPTIONAL_COMPONENTS math REQUIRED)
+find_package(YARP 3.11.100 COMPONENTS catch2 dev_tests QUIET)
 
 if(YARP_catch2_FOUND AND YARP_dev_tests_FOUND)
   option(YARP_COMPILE_TESTS "Enable YARP tests" OFF)

--- a/src/devices/rangefinder2D_nwc_ros2/Rangefinder2D_nwc_ros2.cpp
+++ b/src/devices/rangefinder2D_nwc_ros2/Rangefinder2D_nwc_ros2.cpp
@@ -85,98 +85,98 @@ void Rangefinder2D_nwc_ros2::callback(sensor_msgs::msg::LaserScan::SharedPtr msg
     m_timestamp = (msg->header.stamp.sec + (msg->header.stamp.nanosec / 1000000000));
 }
 
-bool Rangefinder2D_nwc_ros2::getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp)
+ReturnValue Rangefinder2D_nwc_ros2::getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
     *timestamp = m_timestamp;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2D_nwc_ros2::getRawData(yarp::sig::Vector &data, double* timestamp)
+ReturnValue Rangefinder2D_nwc_ros2::getRawData(yarp::sig::Vector &data, double* timestamp)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
     data = m_data;
     *timestamp = m_timestamp;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2D_nwc_ros2::getDeviceStatus(Device_status& status)
+ReturnValue Rangefinder2D_nwc_ros2::getDeviceStatus(Device_status& status)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2D_nwc_ros2::getDistanceRange(double& min, double& max)
+ReturnValue Rangefinder2D_nwc_ros2::getDistanceRange(double& min, double& max)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
     min = m_minDistance;
     max = m_maxDistance;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2D_nwc_ros2::setDistanceRange(double min, double max)
+ReturnValue Rangefinder2D_nwc_ros2::setDistanceRange(double min, double max)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
     yCTrace(RANGEFINDER2D_NWC_ROS2, "setDistanceRange not implemented");
-    return false;
+    return YARP_METHOD_NOT_YET_IMPLEMENTED();
 }
 
-bool Rangefinder2D_nwc_ros2::getScanLimits(double& min, double& max)
+ReturnValue Rangefinder2D_nwc_ros2::getScanLimits(double& min, double& max)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
     min = m_minAngle;
     max = m_maxAngle;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2D_nwc_ros2::setScanLimits(double min, double max)
+ReturnValue Rangefinder2D_nwc_ros2::setScanLimits(double min, double max)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
     yCTrace(RANGEFINDER2D_NWC_ROS2, "setScanLimits not implemented");
-    return false;
+    return YARP_METHOD_NOT_YET_IMPLEMENTED();
 }
 
-bool Rangefinder2D_nwc_ros2::getHorizontalResolution(double& step)
+ReturnValue Rangefinder2D_nwc_ros2::getHorizontalResolution(double& step)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
     step = m_resolution;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2D_nwc_ros2::setHorizontalResolution(double step)
+ReturnValue Rangefinder2D_nwc_ros2::setHorizontalResolution(double step)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
     yCTrace(RANGEFINDER2D_NWC_ROS2, "setHorizontalResolution not implemented");
-    return false;
+    return YARP_METHOD_NOT_YET_IMPLEMENTED();
 }
 
-bool Rangefinder2D_nwc_ros2::getScanRate(double& rate)
+ReturnValue Rangefinder2D_nwc_ros2::getScanRate(double& rate)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
-    return true;
+    return ReturnValue_ok;
 }
 
-bool Rangefinder2D_nwc_ros2::setScanRate(double rate)
+ReturnValue Rangefinder2D_nwc_ros2::setScanRate(double rate)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
     yCTrace(RANGEFINDER2D_NWC_ROS2, "setScanRate not implemented");
-    return false;
+    return YARP_METHOD_NOT_YET_IMPLEMENTED();
 }
 
-bool Rangefinder2D_nwc_ros2::getDeviceInfo(std::string &device_info)
+ReturnValue Rangefinder2D_nwc_ros2::getDeviceInfo(std::string &device_info)
 {
-    if (!m_data_valid) {return false;}
+    if (!m_data_valid) {return ReturnValue::return_code::return_value_error_generic;}
     std::lock_guard<std::mutex> data_guard(m_mutex);
-    return true;
+    return ReturnValue_ok;
 }

--- a/src/devices/rangefinder2D_nwc_ros2/Rangefinder2D_nwc_ros2.h
+++ b/src/devices/rangefinder2D_nwc_ros2/Rangefinder2D_nwc_ros2.h
@@ -54,18 +54,18 @@ public:
 
 public:
     // IRangeFinder2D
-    bool getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp = nullptr) override;
-    bool getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) override;
-    bool getDeviceStatus(Device_status& status) override;
-    bool getDistanceRange(double& min, double& max) override;
-    bool setDistanceRange(double min, double max) override;
-    bool getScanLimits(double& min, double& max) override;
-    bool setScanLimits(double min, double max) override;
-    bool getHorizontalResolution(double& step) override;
-    bool setHorizontalResolution(double step) override;
-    bool getScanRate(double& rate) override;
-    bool setScanRate(double rate) override;
-    bool getDeviceInfo(std::string &device_info) override;
+    yarp::dev::ReturnValue getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp = nullptr) override;
+    yarp::dev::ReturnValue getRawData(yarp::sig::Vector &data, double* timestamp = nullptr) override;
+    yarp::dev::ReturnValue getDeviceStatus(Device_status& status) override;
+    yarp::dev::ReturnValue getDistanceRange(double& min, double& max) override;
+    yarp::dev::ReturnValue setDistanceRange(double min, double max) override;
+    yarp::dev::ReturnValue getScanLimits(double& min, double& max) override;
+    yarp::dev::ReturnValue setScanLimits(double min, double max) override;
+    yarp::dev::ReturnValue getHorizontalResolution(double& step) override;
+    yarp::dev::ReturnValue setHorizontalResolution(double step) override;
+    yarp::dev::ReturnValue getScanRate(double& rate) override;
+    yarp::dev::ReturnValue setScanRate(double rate) override;
+    yarp::dev::ReturnValue getDeviceInfo(std::string &device_info) override;
 
 private:
     rclcpp::Node::SharedPtr m_node;


### PR DESCRIPTION
Now `rangefinder2D_nwc_yarp` device is compatible with the newly modified `IRangefinder2D` (see  [yarp PR#3180](https://github.com/robotology/yarp/pull/3180))

Github workflow and the main CMakeLists.txt of the repo have been updated as well