### PR TITLE
Remove duplicate member in controlBoard device

### DIFF
--- a/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2.h
+++ b/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2.h
@@ -73,7 +73,6 @@ private:
     std::vector<std::string>     m_jointNames; // name of the joints
     std::string                  m_nodeName;                // name of the rosNode
     std::string                  m_jointStateTopicName;               // name of the rosTopic
-    std::string                  m_msgs_name;
     std::string                  m_posTopicName;
     std::string                  m_posDirTopicName;
     std::string                  m_velTopicName;


### PR DESCRIPTION
The parsed `msgs_name` member was being shadowed. See

https://github.com/robotology/yarp-devices-ros2/blob/c3c2f0b24214f16d41d522af0dfc0c97349dbded/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2_ParamsParser.h#L68

and

https://github.com/robotology/yarp-devices-ros2/blob/c3c2f0b24214f16d41d522af0dfc0c97349dbded/src/devices/controlBoard_nws_ros2/ControlBoard_nws_ros2.h#L76