### PR TITLE
Little ros2 kilted kaiju compatiblity fix

### DIFF
--- a/src/devices/frameGrabber_nws_ros2/FrameGrabber_nws_ros2.h
+++ b/src/devices/frameGrabber_nws_ros2/FrameGrabber_nws_ros2.h
@@ -6,8 +6,6 @@
 #ifndef YARP_FRAMEGRABBER_NWS_ROS2_H
 #define YARP_FRAMEGRABBER_NWS_ROS2_H
 
-#include <yarp/os/Node.h>
-#include <yarp/os/Publisher.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/RpcServer.h>
 #include <yarp/os/Stamp.h>

--- a/src/devices/map2D_nws_ros2/Map2D_nws_ros2.cpp
+++ b/src/devices/map2D_nws_ros2/Map2D_nws_ros2.cpp
@@ -90,19 +90,20 @@ bool Map2D_nws_ros2::open(yarp::os::Searchable &config)
         return false;
     }
     m_node = NodeCreator::createNode(m_node_name);
-    rmw_qos_profile_t qos;
-    qos.history = RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT;
-    qos.depth=10;
+    rmw_qos_profile_t qos_rmw;
+    qos_rmw.history = RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT;
+    qos_rmw.depth=10;
     rmw_time_t time;
     time.sec=10000;
     time.nsec = 0;
-    qos.deadline= time;
-    qos.lifespan=time;
-    qos.liveliness_lease_duration=time;
-    qos.reliability = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
-    qos.durability = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
-    qos.liveliness = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
-    qos.avoid_ros_namespace_conventions = true;
+    qos_rmw.deadline= time;
+    qos_rmw.lifespan=time;
+    qos_rmw.liveliness_lease_duration=time;
+    qos_rmw.reliability = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
+    qos_rmw.durability = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
+    qos_rmw.liveliness = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
+    qos_rmw.avoid_ros_namespace_conventions = true;
+    rclcpp::QoS qos(rclcpp::QoSInitialization::from_rmw(qos_rmw));
     m_ros2Service_getMap = m_node->create_service<nav_msgs::srv::GetMap>(m_getmap,
                                                                                        std::bind(&Map2D_nws_ros2::getMapCallback,this,_1,_2,_3),qos );
     m_ros2Service_getMapByName = m_node->create_service<map2d_nws_ros2_msgs::srv::GetMapByName>(m_getmapbyname,


### PR DESCRIPTION
This PR contains a little fix in order to be able to compile the repo with `ros2 kilted-kaiju`. The code is still compatible with ros2 jazzy